### PR TITLE
upgrade to v4.0.1 with quad quote fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "CoffeeScript"
   ],
   "dependencies": {
-    "cson-parser": "1.3.4",
+    "@richardtks/cson-parser": "4.0.1",
     "fs-plus": "2.x",
     "optimist": "~0.4.0"
   },


### PR DESCRIPTION
# Motivation
Fix the scenario where the content contains quad quotes

For etc
```
'''' => \''\''
```